### PR TITLE
chore: added hook for validating commit format

### DIFF
--- a/Sources/Run/Validate.swift
+++ b/Sources/Run/Validate.swift
@@ -2,12 +2,11 @@ import ArgumentParser
 import Versioning
 
 struct Validate: ParsableCommand {
-    mutating func run() throws {
-        print("hi")
-        
-    }
+    @Option(name: .shortAndLong, help: "A commit message to validate")
+    private var message: String
     
-    static func validateCommits(messages: [String]) throws {
-        _ = try messages.map(Commit.init)
+    mutating func run() throws {
+        _ = try Commit(string: message)
+        print("Validated commit message (\(message)) successfully")
     }
 }

--- a/Sources/Versioning/Commit.swift
+++ b/Sources/Versioning/Commit.swift
@@ -1,8 +1,3 @@
-enum CommitError: Error {
-    case invalidStructure
-    case invalidPrefix
-}
-
 public struct Commit {
     public let type: CommitType
     public let isBreakingChange: Bool
@@ -19,7 +14,7 @@ public struct Commit {
     public init(string: String) throws {
         let components = string.split(separator: ": ")
         guard components.count == 2 else {
-            throw CommitError.invalidStructure
+            throw CommitFormatError.invalid
         }
     
         self.isBreakingChange = components[0].last == "!"
@@ -31,7 +26,7 @@ public struct Commit {
         } else if let type = CommitType(rawValue: String(components[0])) {
             self.type = type
         } else {
-            throw CommitError.invalidPrefix
+            throw CommitFormatError.invalidPrefix(components[0])
         }
         
         message = String(components[1])

--- a/Sources/Versioning/CommitFormatError.swift
+++ b/Sources/Versioning/CommitFormatError.swift
@@ -1,0 +1,24 @@
+enum CommitFormatError: Error {
+    case invalid
+    case invalidPrefix(Substring)
+}
+extension CommitFormatError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .invalid:
+            """
+            \u{001B}[0;31mInvalid commit message format.
+            \u{001B}[0;33m
+            Please use Conventional Commits.
+            https://www.conventionalcommits.org
+            """
+        case .invalidPrefix(let prefix):
+            """
+            \u{001B}[0;31m"\(prefix)" is not an allowed commit prefix.
+            \u{001B}[0;33m
+            Allowed prefixes include feat, fix, test, refactor, ci.
+            See the specification: https://www.conventionalcommits.org
+            """
+        }
+    }
+}

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -29,14 +29,14 @@ final class CommitTests: XCTestCase {
         do {
             _ = try Commit(string: "invalid: adding-optional-initialiser-for-icon")
             XCTFail("Expected error to be thrown")
-        } catch CommitError.invalidPrefix { }
+        } catch CommitFormatError.invalidPrefix { }
     }
     
     func testThrowsInvalidStructureError() throws {
         do {
             _ = try Commit(string: "feat with no colon / message")
             XCTFail("Expected error to be thrown")
-        } catch CommitError.invalidStructure { }
+        } catch CommitFormatError.invalid { }
     }
     
     func testVersionIncrementValues() throws {

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+commit_message=$(head -1 $1)
+swift run Run --message "$commit_message"


### PR DESCRIPTION
Added a commit hook to the `hooks` directory which validates the commit message that the user has entered.