### PR TITLE
feat: output version from GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ You can also use it to validate a list of commits when using merge commits or re
 steps:
   - uses: actions/checkout@v4
   
-  - id: Versioning
+  - name: Validate Pull Request Name
+    id: versioning
     uses: Oliver-Binns/Versioning@main
     with:
       ACTION_TYPE: 'Validate'
@@ -41,11 +42,19 @@ jobs:
 And pass the GitHub Token as a parameter:
 
 ```
-- id: Versioning
+- name: Increment Version
+  id: versioning
   uses: Oliver-Binns/Versioning@main
   with:
     ACTION_TYPE: 'Release'
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The release action outputs the version number it has released.
+You can access it using the GitHub output values:
+
+```
+echo ${{ steps.versioning.outputs.release_version }}
 ```
 
 ### Swift Package Manager

--- a/Sources/Run/Increment.swift
+++ b/Sources/Run/Increment.swift
@@ -12,8 +12,12 @@ struct Increment: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "A token that you can use to authenticate on behalf of GitHub Actions")
     private var token: String
     
-    mutating func run() async throws {
+    @Flag(name: .shortAndLong)
+    private var verbose = false
+    
+    mutating func run() async throws -> Version? {
         let session = GitHubAPISession(repository: repository, apiToken: token)
-        try await Releaser(session: session).makeRelease(sha: sha)
+        return try await Releaser(session: session, verbose: verbose)
+            .makeRelease(sha: sha)
     }
 }

--- a/Tests/RunTests/ParserTests.swift
+++ b/Tests/RunTests/ParserTests.swift
@@ -1,4 +1,5 @@
 @testable import Run
+import Versioning
 import XCTest
 
 final class ReleaserTests: XCTestCase {
@@ -7,7 +8,7 @@ final class ReleaserTests: XCTestCase {
         
         let sha = UUID().uuidString
         let sut = Releaser(session: session)
-        try await sut.makeRelease(sha: sha)
+        let version = try await sut.makeRelease(sha: sha)
         
         XCTAssertEqual(session.didCallCompare?.0, "HEAD^")
         XCTAssertEqual(session.didCallCompare?.1, sha)
@@ -15,6 +16,8 @@ final class ReleaserTests: XCTestCase {
         XCTAssertEqual(session.didCallCreateReference?.0, "0.2.1")
         XCTAssertEqual(session.didCallCreateReference?.1, sha)
         XCTAssertEqual(session.didCallCreateRelease, "0.2.1")
+        
+        XCTAssertEqual(version, Version(0, 2, 1))
     }
     
     func testReleaseWhenRelease() async throws {
@@ -23,7 +26,7 @@ final class ReleaserTests: XCTestCase {
         
         let sha = UUID().uuidString
         let sut = Releaser(session: session)
-        try await sut.makeRelease(sha: sha)
+        let version = try await sut.makeRelease(sha: sha)
         
         XCTAssertEqual(session.didCallCompare?.0, "1.0.0")
         XCTAssertEqual(session.didCallCompare?.1, sha)
@@ -31,5 +34,7 @@ final class ReleaserTests: XCTestCase {
         XCTAssertEqual(session.didCallCreateReference?.0, "1.2.1")
         XCTAssertEqual(session.didCallCreateReference?.1, sha)
         XCTAssertEqual(session.didCallCreateRelease, "1.2.1")
+        
+        XCTAssertEqual(version, Version(1, 2, 1))
     }
 }

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
 name: 'Release Version'
 description: 'Create new GitHub release using Conventional Commits'
+
 inputs:
   GITHUB_TOKEN:
     description: 'GitHub Actions token with write permissions, see docs: https://docs.github.com/en/actions/security-guides/automatic-token-authentication'
@@ -12,6 +13,11 @@ inputs:
     - Release
     - Validate
     
+outputs:
+  release_version:
+    description: "Release version in semantic format; e.g. 1.0.0"
+    value: ${{ steps.release.outputs.version }}
+
 runs:
   using: "composite"
   steps:
@@ -35,6 +41,7 @@ runs:
          --message "${{ github.event.pull_request.title }}"
       
     - name: Release
+      id: release
       if: ${{ inputs.ACTION_TYPE == 'Release' }}
       working-directory: $RUNNER_TEMP/Versioning
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -46,8 +46,10 @@ runs:
       working-directory: $RUNNER_TEMP/Versioning
       shell: bash
       run: |
-        swift run --skip-build Run increment \
+        version=$(swift run --skip-build Run increment \
           --repository $GITHUB_REPOSITORY \
           --sha $GITHUB_SHA \
-          --token ${{inputs.GITHUB_TOKEN}}
+          --token ${{inputs.GITHUB_TOKEN}})
+          
+        echo "release_version=$(echo $version)" >> $GITHUB_OUTPUT
         

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,7 @@ runs:
           --repository $GITHUB_REPOSITORY \
           --sha $GITHUB_SHA \
           --token ${{inputs.GITHUB_TOKEN}})
-          
-        echo "release_version=$(echo $version)" >> $GITHUB_OUTPUT
+        
+        echo $version
+        echo "version=$version" >> $GITHUB_OUTPUT
         

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,5 @@ runs:
           --sha $GITHUB_SHA \
           --token ${{inputs.GITHUB_TOKEN}})
         
-        echo $version
         echo "version=$version" >> $GITHUB_OUTPUT
         


### PR DESCRIPTION
The new version that is created is now output from the Custom GitHub action. This means that the script can be run as part of a deploy pipeline for App Store apps, with the output being used to create the correct build.