### PR TITLE
chore: adding message to invalid commit error

### DIFF
--- a/Sources/Versioning/Commit.swift
+++ b/Sources/Versioning/Commit.swift
@@ -14,7 +14,7 @@ public struct Commit {
     public init(string: String) throws {
         let components = string.split(separator: ": ")
         guard components.count == 2 else {
-            throw CommitFormatError.invalid
+            throw CommitFormatError.invalid(string)
         }
     
         self.isBreakingChange = components[0].last == "!"

--- a/Sources/Versioning/CommitFormatError.swift
+++ b/Sources/Versioning/CommitFormatError.swift
@@ -1,13 +1,13 @@
 enum CommitFormatError: Error {
-    case invalid
+    case invalid(String)
     case invalidPrefix(Substring)
 }
 extension CommitFormatError: CustomStringConvertible {
     var description: String {
         switch self {
-        case .invalid:
+        case .invalid(let message):
             return """
-            \u{001B}[0;31mInvalid commit message format.
+            \u{001B}[0;31mInvalid commit message format: \(message)
             \u{001B}[0;33m
             Please use Conventional Commits.
             https://www.conventionalcommits.org


### PR DESCRIPTION
Passing the commit message into the invalid commit error to give more visibility on which commit is causing the error to be thrown