### PR TITLE
fix: allows multi line commit message to pass and make release

### DIFF
--- a/Sources/Versioning/Commit.swift
+++ b/Sources/Versioning/Commit.swift
@@ -13,7 +13,7 @@ public struct Commit {
     
     public init(string: String) throws {
         let components = string.split(separator: ": ")
-        guard components.count == 2 else {
+        guard components.count >= 2 else {
             throw CommitFormatError.invalid(string)
         }
     

--- a/Sources/Versioning/Commit.swift
+++ b/Sources/Versioning/Commit.swift
@@ -12,7 +12,7 @@ public struct Commit {
     }
     
     public init(string: String) throws {
-        let components = string.split(separator: ": ")
+        let components = string.split(separator: ": ", maxSplits: 1)
         guard components.count >= 2 else {
             throw CommitFormatError.invalid(string)
         }

--- a/Sources/Versioning/Commit.swift
+++ b/Sources/Versioning/Commit.swift
@@ -13,7 +13,7 @@ public struct Commit {
     
     public init(string: String) throws {
         let components = string.split(separator: ": ", maxSplits: 1)
-        guard components.count >= 2 else {
+        guard components.count == 2 else {
             throw CommitFormatError.invalid(string)
         }
     

--- a/Tests/RunTests/MockAPISession.swift
+++ b/Tests/RunTests/MockAPISession.swift
@@ -3,7 +3,7 @@ import GitHubAPI
 
 final class MockAPISession: APISession {
     var previousReleaseExists: Bool = false
-    
+    var useMultiCommit: Bool = false
     var didCallCompare: (String, String)?
     
     var didCallCreateReference: (String, String)?
@@ -19,7 +19,7 @@ final class MockAPISession: APISession {
     func compare(base: String, head: String) async throws -> [String] {
         didCallCompare = (base, head)
         
-        return [
+        var listOfCommit =  [
             "chore: implement pipelines for Cards",
             "chore: fix Fastlane deployment",
             "chore: fixed warnings in latest version of Xcode",
@@ -29,6 +29,16 @@ final class MockAPISession: APISession {
             "feat: use button rather than tap recogniser",
             "fix: fixed compilation issues on Linux"
         ]
+        
+        if useMultiCommit {
+            listOfCommit.insert("""
+feat: implement pipelines for Cards
+* fix: implement pipelines for Cards
+* chore: fix Fastlane deployment
+""", at: 0)
+        }
+        
+        return listOfCommit
     }
     
     func createReference(version: String, sha: String) async throws {

--- a/Tests/RunTests/ParserTests.swift
+++ b/Tests/RunTests/ParserTests.swift
@@ -38,7 +38,7 @@ final class ReleaserTests: XCTestCase {
         XCTAssertEqual(version, Version(1, 2, 1))
     }
     
-    func testReleaseWhenReleaseWithMultilineCommitMessage() async throws {
+    func testReleaseOfSquashedCommits() async throws {
         let session = MockAPISession()
         session.previousReleaseExists = true
         session.useMultiCommit = true

--- a/Tests/RunTests/ParserTests.swift
+++ b/Tests/RunTests/ParserTests.swift
@@ -38,7 +38,7 @@ final class ReleaserTests: XCTestCase {
         XCTAssertEqual(version, Version(1, 2, 1))
     }
     
-    func testReleaseWhenReleaseWithMutilCommitMessage() async throws {
+    func testReleaseWhenReleaseWithMultilineCommitMessage() async throws {
         let session = MockAPISession()
         session.previousReleaseExists = true
         session.useMultiCommit = true

--- a/Tests/RunTests/ParserTests.swift
+++ b/Tests/RunTests/ParserTests.swift
@@ -37,4 +37,23 @@ final class ReleaserTests: XCTestCase {
         
         XCTAssertEqual(version, Version(1, 2, 1))
     }
+    
+    func testReleaseWhenReleaseWithMutilCommitMessage() async throws {
+        let session = MockAPISession()
+        session.previousReleaseExists = true
+        session.useMultiCommit = true
+        
+        let sha = UUID().uuidString
+        let sut = Releaser(session: session)
+        let version = try await sut.makeRelease(sha: sha)
+        
+        XCTAssertEqual(session.didCallCompare?.0, "1.0.0")
+        XCTAssertEqual(session.didCallCompare?.1, sha)
+        
+        XCTAssertEqual(session.didCallCreateReference?.0, "1.3.1")
+        XCTAssertEqual(session.didCallCreateReference?.1, sha)
+        XCTAssertEqual(session.didCallCreateRelease, "1.3.1")
+        
+        XCTAssertEqual(version, Version(1, 3, 1))
+    }
 }

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -25,7 +25,7 @@ final class CommitTests: XCTestCase {
         }
     }
     
-    func testCommitWithMultilineCommits() throws {
+    func testSquashedCommits() throws {
         let commit = try Commit(string: """
 feat: DCMAW-7932 Automate Versioning (#50)
 * chore: added a new step on pull request.yml to validate PR names

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -25,6 +25,23 @@ final class CommitTests: XCTestCase {
         }
     }
     
+    func testCommitWithMutileCommits() throws {
+        let commit = try Commit(string: """
+feat: DCMAW-7932 Automate Versioning (#50)
+* chore: added a new step on pull request.yml to validate PR names
+
+* chore: update quality report.yml to include increment version job
+
+* chore: moved validate job to before build and test action
+""")
+        XCTAssertEqual(commit.type, .feature)
+        XCTAssertFalse(commit.isBreakingChange)
+        XCTAssertEqual(commit.message, """
+DCMAW-7932 Automate Versioning (#50)
+* chore
+""")
+    }
+    
     func testThrowsInvalidPrefixError() throws {
         do {
             _ = try Commit(string: "invalid: adding-optional-initialiser-for-icon")

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -38,7 +38,11 @@ feat: DCMAW-7932 Automate Versioning (#50)
         XCTAssertFalse(commit.isBreakingChange)
         XCTAssertEqual(commit.message, """
 DCMAW-7932 Automate Versioning (#50)
-* chore
+* chore: added a new step on pull request.yml to validate PR names
+
+* chore: update quality report.yml to include increment version job
+
+* chore: moved validate job to before build and test action
 """)
     }
     

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -25,7 +25,7 @@ final class CommitTests: XCTestCase {
         }
     }
     
-    func testCommitWithMutileCommits() throws {
+    func testCommitWithMultilineCommits() throws {
         let commit = try Commit(string: """
 feat: DCMAW-7932 Automate Versioning (#50)
 * chore: added a new step on pull request.yml to validate PR names


### PR DESCRIPTION
Fixed an issue when making release with a commit message that contains multiple lines of commits. Usually this is caused by squashing pull request commit history during a merge.

The fix itself utilises the `maxSplits` parameter of the `string.split` method in Swift.