### PR TITLE
feat: adding build as a patch version increment

### DIFF
--- a/Sources/Versioning/Commit.swift
+++ b/Sources/Versioning/Commit.swift
@@ -42,7 +42,7 @@ extension Commit {
         switch type {
         case .feature:
             return .minor
-        case .fix, .refactor, .style:
+        case .fix, .refactor, .style, .build:
             return .patch
         default:
             return nil

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -50,14 +50,36 @@ DCMAW-7932 Automate Versioning (#50)
         do {
             _ = try Commit(string: "invalid: adding-optional-initialiser-for-icon")
             XCTFail("Expected error to be thrown")
-        } catch CommitFormatError.invalidPrefix { }
+        } catch CommitFormatError.invalidPrefix(let string) {
+            XCTAssertEqual(string, "invalid")
+        }
+    }   
+    
+    func testThrowsInvalidPrefixErrorDescription() throws {
+        do {
+            _ = try Commit(string: "invalid: adding-optional-initialiser-for-icon")
+            XCTFail("Expected error to be thrown")
+        } catch let error as CommitFormatError {
+            XCTAssertTrue(error.description.contains("\"invalid\" is not an allowed commit prefix."))
+        }
     }
     
     func testThrowsInvalidStructureError() throws {
         do {
             _ = try Commit(string: "feat with no colon / message")
             XCTFail("Expected error to be thrown")
-        } catch CommitFormatError.invalid { }
+        } catch CommitFormatError.invalid(let string) {
+            XCTAssertEqual(string, "feat with no colon / message")
+        }
+    }   
+    
+    func testThrowsInvalidStructureErrorDescription() throws {
+        do {
+            _ = try Commit(string: "feat with no colon / message")
+            XCTFail("Expected error to be thrown")
+        } catch let error as CommitFormatError {
+            XCTAssertTrue(error.description.contains("Invalid commit message format: feat with no colon / message"))
+        }
     }
     
     func testVersionIncrementValues() throws {


### PR DESCRIPTION
Adding `build` conventional commit header to the list of patch version incrementing headers.
This change involves additional [configuration to dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message) YAML files to ensure PRs follow this header convention.
Also adding some basic tests missed in #10