### PR TITLE
chore: add products to package file

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,12 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect breaking changes
+    	run: swift package diagnose-api-breaking-changes main
     
       - name: Validate pull request title
         run: swift run Run --message "${{ github.event.pull_request.title }}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,13 +17,8 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-    
-      - name: Detect breaking changes
-        run: swift package diagnose-api-breaking-changes 1.1.0
-    
+        uses: actions/checkout@v3
+
       - name: Validate pull request title
         run: swift run Run --message "${{ github.event.pull_request.title }}"
     

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
+    
       - name: Detect breaking changes
-    	run: swift package diagnose-api-breaking-changes main
+        run: swift package diagnose-api-breaking-changes main
     
       - name: Validate pull request title
         run: swift run Run --message "${{ github.event.pull_request.title }}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
     
       - name: Detect breaking changes
-        run: swift package diagnose-api-breaking-changes main
+        run: swift package diagnose-api-breaking-changes 1.1.0
     
       - name: Validate pull request title
         run: swift run Run --message "${{ github.event.pull_request.title }}"

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,10 @@ let package = Package(
         .watchOS(.v9),
         .tvOS(.v16)
     ],
+    products: [
+        .executable(name: "Run", targets: ["Run"]),
+        .library(name: "Versioning", targets: ["Versioning", "GitHubAPI"])
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.2.3"))
     ],


### PR DESCRIPTION
Declared 
- run as an executable
- Versioning and GitHubAPI as libraries

in the Package.swift manifest file, so they can be imported.