### PR TITLE
feat: allow scopes in commit message

### DIFF
--- a/Sources/Versioning/Commit.swift
+++ b/Sources/Versioning/Commit.swift
@@ -25,6 +25,9 @@ public struct Commit {
             self.type = CommitType(rawValue: String(trimmedExclamation))!
         } else if let type = CommitType(rawValue: String(components[0])) {
             self.type = type
+        } else if let trimmedType = components[0].components(separatedBy: "(").first,
+                  let type = CommitType(rawValue: trimmedType) {
+            self.type = type
         } else {
             throw CommitFormatError.invalidPrefix(components[0])
         }

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -9,9 +9,17 @@ final class CommitTests: XCTestCase {
         XCTAssertEqual(commit.message, "adding-optional-initialiser-for-icon")
     }
     
-    func testCommitTypes() throws {
+    func testCommitTypesWithoutDeps() throws {
         try CommitType.allCases.forEach {
             let message = "\($0.rawValue): commit message here"
+            let commit = try Commit(string: message)
+            XCTAssertEqual($0, commit.type)
+        }
+    }
+
+    func testCommitTypesWithDeps() throws {
+        try CommitType.allCases.forEach {
+            let message = "\($0.rawValue)(dep): commit message here"
             let commit = try Commit(string: message)
             XCTAssertEqual($0, commit.type)
         }

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -19,7 +19,7 @@ final class CommitTests: XCTestCase {
 
     func testCommitTypesWithDeps() throws {
         try CommitType.allCases.forEach {
-            let message = "\($0.rawValue)(dep): commit message here"
+            let message = "\($0.rawValue)(dep something something: commit message here"
             let commit = try Commit(string: message)
             XCTAssertEqual($0, commit.type)
         }
@@ -87,6 +87,15 @@ DCMAW-7932 Automate Versioning (#50)
             XCTFail("Expected error to be thrown")
         } catch let error as CommitFormatError {
             XCTAssertTrue(error.description.contains("Invalid commit message format: feat with no colon / message"))
+        }
+    }
+    
+    func testThrowsInvalidScopeError() throws {
+        do {
+            _ = try Commit(string: "feat:(no closing parenthesis")
+            XCTFail("Expected error to be thrown")
+        } catch let error as CommitFormatError {
+            XCTAssertTrue(error.description.contains("Invalid scope format: missing closing parenthesis"))
         }
     }
     

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -124,6 +124,11 @@ DCMAW-7932 Automate Versioning (#50)
         )
 
         try XCTAssertEqual(
+            Commit(string: "build: adding-optional-initialiser-for-icon").versionIncrement,
+            .patch
+        )
+
+        try XCTAssertEqual(
             Commit(string: "ci: adding-optional-initialiser-for-icon").versionIncrement,
             nil
         )
@@ -142,6 +147,11 @@ DCMAW-7932 Automate Versioning (#50)
         
         try XCTAssertEqual(
             Commit(string: "fix(example-scope): adding-optional-initialiser-for-icon").versionIncrement,
+            .patch
+        )
+
+        try XCTAssertEqual(
+            Commit(string: "build(deps): adding-optional-initialiser-for-icon").versionIncrement,
             .patch
         )
 


### PR DESCRIPTION
This allows the use of a scope in commit messages to align more closely with the conventional commit specification.

Specification: https://www.conventionalcommits.org/en/v1.0.0/
