### PR TITLE
feat: add support for scopes in commit messages

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,12 @@ let package = Package(
         ]),
         .testTarget(name: "RunTests", dependencies: ["Run"]),
         
-        .target(name: "Versioning"),
+        .target(
+            name: "Versioning",
+            swiftSettings: [
+                .unsafeFlags(["-enable-bare-slash-regex"])
+            ]
+        ),
         .testTarget(name: "VersioningTests", dependencies: ["Versioning"]),
         
         .target(name: "GitHubAPI"),

--- a/Sources/Versioning/Commit.swift
+++ b/Sources/Versioning/Commit.swift
@@ -1,22 +1,43 @@
 public struct Commit {
     public let type: CommitType
+    public let scope: String?
     public let isBreakingChange: Bool
     public let message: String
-    
+
     init(type: CommitType,
+         scope: String? = nil,
          isBreakingChange: Bool,
          message: String) {
         self.type = type
+        self.scope = scope
         self.isBreakingChange = isBreakingChange
         self.message = message
     }
     
     public init(string: String) throws {
-        let components = string.split(separator: ": ", maxSplits: 1)
+        let search = /(?<type>[a-z]+)(\((?<scope>[a-z]+)\))?(?<breaking>!)?: (?<message>(.|\n)+)/
+
+        do {
+            guard let match = try search.wholeMatch(in: string) else {
+                throw CommitFormatError.invalid(string)
+            }
+
+            guard let type = CommitType(rawValue: String(match.output.type)) else {
+                throw CommitFormatError.invalidPrefix(match.output.type)
+            }
+            self.type = type
+            self.scope = match.output.scope.map(String.init)
+            self.isBreakingChange = match.output.breaking != nil
+            self.message = String(match.output.message)
+        }
+
+
+        /*let components = string.split(separator: ": ", maxSplits: 1)
         guard components.count == 2 else {
             throw CommitFormatError.invalid(string)
         }
-    
+
+        self.scope = nil
         self.isBreakingChange = components[0].last == "!"
         
         if isBreakingChange {
@@ -29,7 +50,7 @@ public struct Commit {
             throw CommitFormatError.invalidPrefix(components[0])
         }
         
-        message = String(components[1])
+        message = String(components[1])*/
     }
 }
 

--- a/Tests/VersioningTests/CommitTests.swift
+++ b/Tests/VersioningTests/CommitTests.swift
@@ -103,4 +103,11 @@ DCMAW-7932 Automate Versioning (#50)
             nil
         )
     }
+
+    func testParsesScope() throws {
+        try XCTAssertEqual(
+            Commit(string: "build(deps): bump github.com/apple/swift-argument-parser from 1.2.3 to 1.5.0 ").scope,
+            "deps"
+        )
+    }
 }


### PR DESCRIPTION
This pull request adds support for commit messages containing a scope, for example: `feat(lang): add Polish language`.

https://www.conventionalcommits.org/en/v1.0.0/#commit-message-with-scope

