### PR TITLE
feat: convert create GitHub release into optional step

### DIFF
--- a/Sources/Run/Increment.swift
+++ b/Sources/Run/Increment.swift
@@ -11,14 +11,17 @@ struct Increment: AsyncParsableCommand {
     
     @Option(name: .shortAndLong, help: "A token that you can use to authenticate on behalf of GitHub Actions")
     private var token: String
-    
+
+    @Option(name: .long, help: "True if a Git tag should be created but not a GitHub release")
+    private var tagOnly: Bool = false
+
     @Flag(name: .shortAndLong)
     private var verbose = false
     
     mutating func run() async throws {
         let session = GitHubAPISession(repository: repository, apiToken: token)
         if let version = try await Releaser(session: session, verbose: verbose)
-            .makeRelease(sha: sha) {
+            .makeRelease(sha: sha, tagOnly: tagOnly) {
             print(version)
         }
     }

--- a/Sources/Run/Releaser.swift
+++ b/Sources/Run/Releaser.swift
@@ -10,7 +10,7 @@ struct Releaser {
         self.verbose = verbose
     }
     
-    func makeRelease(sha: String) async throws -> Version? {
+    func makeRelease(sha: String, tagOnly: Bool = false) async throws -> Version? {
         let (initialVersion, commits) = try await fetchCommits(sha: sha)
         let newVersion = try incrementVersion(initialVersion, commits: commits)
         
@@ -20,7 +20,11 @@ struct Releaser {
         }
         
         try await session.createReference(version: newVersion.description, sha: sha)
-        try await session.createRelease(version: newVersion.description)
+
+        if !tagOnly {
+            try await session.createRelease(version: newVersion.description)
+        }
+        
         log("Released new version: \(newVersion)")
         return newVersion
     }

--- a/Tests/RunTests/ReleaserTests.swift
+++ b/Tests/RunTests/ReleaserTests.swift
@@ -37,7 +37,25 @@ final class ReleaserTests: XCTestCase {
         
         XCTAssertEqual(version, Version(1, 2, 1))
     }
-    
+
+    func testReleaseWhenTagOnly() async throws {
+        let session = MockAPISession()
+        session.previousReleaseExists = true
+
+        let sha = UUID().uuidString
+        let sut = Releaser(session: session)
+        let version = try await sut.makeRelease(sha: sha, tagOnly: true)
+
+        XCTAssertEqual(session.didCallCompare?.0, "1.0.0")
+        XCTAssertEqual(session.didCallCompare?.1, sha)
+
+        XCTAssertEqual(session.didCallCreateReference?.0, "1.2.1")
+        XCTAssertEqual(session.didCallCreateReference?.1, sha)
+        XCTAssertNil(session.didCallCreateRelease)
+
+        XCTAssertEqual(version, Version(1, 2, 1))
+    }
+
     func testReleaseOfSquashedCommits() async throws {
         let session = MockAPISession()
         session.previousReleaseExists = true

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,11 @@ inputs:
     options:
     - Release
     - Validate
+  TAG_ONLY:
+    description: 'True if a Git tag should be created but not a GitHub release'
+    required: false
+    type: boolean
+    default: false
 outputs:
   release_version:
     description: "Release version in semantic format; e.g. 1.0.0"
@@ -48,6 +53,8 @@ runs:
         version=$(swift run --skip-build Run increment \
           --repository $GITHUB_REPOSITORY \
           --sha $GITHUB_SHA \
-          --token ${{inputs.GITHUB_TOKEN}})
+          --token ${{inputs.GITHUB_TOKEN}}
+          --tagOnly ${{inputs.TAG_ONLY}}
+        )
         
         echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This enables the release to be created by the consumer instead, if required.

This is likely required if the consumer needs to attach artefacts to the release:
https://github.com/Oliver-Binns/terraform-provider-googleplay/releases/tag/v0.4.2