### PR TITLE
fix: add linebreaks to action script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,8 +53,8 @@ runs:
         version=$(swift run --skip-build Run increment \
           --repository $GITHUB_REPOSITORY \
           --sha $GITHUB_SHA \
-          --token ${{inputs.GITHUB_TOKEN}}
-          --tag-only ${{inputs.TAG_ONLY}}
+          --token ${{inputs.GITHUB_TOKEN}} \
+          --tag-only ${{inputs.TAG_ONLY}} \
         )
         
         echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Ensure `--tag-only` is considered part of the run script even though it is on a new line.