### PR TITLE
feat: making use of prerelease flag for commit message

### DIFF
--- a/Sources/GitHubAPI/GitHubAPISession.swift
+++ b/Sources/GitHubAPI/GitHubAPISession.swift
@@ -6,10 +6,12 @@ import FoundationNetworking
 public final class GitHubAPISession {
     private let session: URLSession
     private let repository: String
+    private let prerelease: Bool
     
     init(sessionConfiguration: URLSessionConfiguration,
          repository: String,
-         apiToken: String) {
+         apiToken: String,
+         prerelease: Bool) {
         sessionConfiguration.httpAdditionalHeaders = [
             "Accept" : "application/vnd.github+json",
             "Authorization" : "token \(apiToken)",
@@ -18,11 +20,12 @@ public final class GitHubAPISession {
         
         self.session = URLSession(configuration: sessionConfiguration)
         self.repository = repository
+        self.prerelease = prerelease
     }
     
-    public convenience init(repository: String, apiToken: String) {
+    public convenience init(repository: String, apiToken: String, prerelease: Bool) {
         self.init(sessionConfiguration: .ephemeral,
-                  repository: repository, apiToken: apiToken)
+                  repository: repository, apiToken: apiToken, prerelease: prerelease)
     }
     
     public func latestRelease() async throws -> String {
@@ -73,7 +76,7 @@ public final class GitHubAPISession {
             name: name,
             tagName: version.description,
             draft: false,
-            prerelease: false,
+            prerelease: prerelease,
             generateReleaseNotes: true
         )
         

--- a/Sources/Run/Increment.swift
+++ b/Sources/Run/Increment.swift
@@ -24,7 +24,7 @@ struct Increment: AsyncParsableCommand {
     mutating func run() async throws {
         let session = GitHubAPISession(repository: repository, apiToken: token, prerelease: prerelease)
         if let version = try await Releaser(session: session, verbose: verbose)
-            .makeRelease(sha: sha, tagOnly: tagOnly, prerelease: prerelease) {
+            .makeRelease(sha: sha, tagOnly: tagOnly) {
             print(version)
         }
     }

--- a/Sources/Run/Increment.swift
+++ b/Sources/Run/Increment.swift
@@ -15,13 +15,16 @@ struct Increment: AsyncParsableCommand {
     @Option(name: .long, help: "True if a Git tag should be created but not a GitHub release")
     private var tagOnly: Bool = false
 
+    @Option(name: .long, help: "True if the release is not a stable version of the code")
+    private var prerelease: Bool = false
+
     @Flag(name: .shortAndLong)
     private var verbose = false
     
     mutating func run() async throws {
-        let session = GitHubAPISession(repository: repository, apiToken: token)
+        let session = GitHubAPISession(repository: repository, apiToken: token, prerelease: prerelease)
         if let version = try await Releaser(session: session, verbose: verbose)
-            .makeRelease(sha: sha, tagOnly: tagOnly) {
+            .makeRelease(sha: sha, tagOnly: tagOnly, prerelease: prerelease) {
             print(version)
         }
     }

--- a/Sources/Run/Releaser.swift
+++ b/Sources/Run/Releaser.swift
@@ -10,19 +10,24 @@ struct Releaser {
         self.verbose = verbose
     }
     
-    func makeRelease(sha: String, tagOnly: Bool = false) async throws -> Version? {
+    func makeRelease(sha: String, tagOnly: Bool = false, prerelease: Bool = false) async throws -> Version? {
         let (initialVersion, commits) = try await fetchCommits(sha: sha)
         let newVersion = try incrementVersion(initialVersion, commits: commits)
+        var newVersionDescription = newVersion.description
+        
+        if prerelease {
+            newVersionDescription += "-alpha"
+        }
         
         guard newVersion > initialVersion else {
             log("Nothing to do: no significant changes made")
             return nil
         }
         
-        try await session.createReference(version: newVersion.description, sha: sha)
+        try await session.createReference(version: newVersionDescription, sha: sha)
 
         if !tagOnly {
-            try await session.createRelease(version: newVersion.description)
+            try await session.createRelease(version: newVersionDescription)
         }
         
         log("Released new version: \(newVersion)")

--- a/Sources/Run/Releaser.swift
+++ b/Sources/Run/Releaser.swift
@@ -10,14 +10,10 @@ struct Releaser {
         self.verbose = verbose
     }
     
-    func makeRelease(sha: String, tagOnly: Bool = false, prerelease: Bool = false) async throws -> Version? {
+    func makeRelease(sha: String, tagOnly: Bool = false) async throws -> Version? {
         let (initialVersion, commits) = try await fetchCommits(sha: sha)
         let newVersion = try incrementVersion(initialVersion, commits: commits)
         var newVersionDescription = newVersion.description
-        
-        if prerelease {
-            newVersionDescription += "-alpha"
-        }
         
         guard newVersion > initialVersion else {
             log("Nothing to do: no significant changes made")

--- a/Tests/GitHubAPITests/GitHubAPISessionTests.swift
+++ b/Tests/GitHubAPITests/GitHubAPISessionTests.swift
@@ -7,13 +7,15 @@ final class GitHubAPISessionTests: XCTestCase {
     
     private var accessToken = UUID().uuidString
     private let repository = "octocat/Hello-World"
+    private let prerelease = false
     
     override func setUp() {
         super.setUp()
         
         sut = GitHubAPISession(sessionConfiguration: .mock,
                                repository: repository,
-                               apiToken: accessToken)
+                               apiToken: accessToken,
+                               prerelease: prerelease)
     }
     
     override func tearDown() {

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,11 @@ inputs:
     options:
     - Release
     - Validate
+  IS_PRERELEASE:
+    description: 'Is the release a prerelease version'
+    required: false
+    type: boolean
+    default: false
   TAG_ONLY:
     description: 'True if a Git tag should be created but not a GitHub release'
     required: false
@@ -55,6 +60,7 @@ runs:
           --sha $GITHUB_SHA \
           --token ${{inputs.GITHUB_TOKEN}} \
           --tag-only ${{inputs.TAG_ONLY}} \
+          --prerelease ${{inputs.IS_PRERELEASE}}
         )
         
         echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adding the ability to pass through a boolean if the release should be tagged as a prerelease. I have also coupled that flag to adding "-alpha" to the end of the version numbers if true, potentially this should be separate or allow the consumers to pass through their own string if desired? 