### PR TITLE
feat: adding option to have suffix with version number

### DIFF
--- a/Sources/Run/Increment.swift
+++ b/Sources/Run/Increment.swift
@@ -15,7 +15,7 @@ struct Increment: AsyncParsableCommand {
     @Option(name: .long, help: "True if a Git tag should be created but not a GitHub release")
     private var tagOnly: Bool = false
     
-    @Option(name: .shortAndLong, help: "A suffix to be added to the end of the version string")
+    @Option(name: .shortAndLong, help: "A suffix added to the end of the version string")
     private var suffix: String?
 
     @Flag(name: .shortAndLong)

--- a/Sources/Run/Increment.swift
+++ b/Sources/Run/Increment.swift
@@ -15,7 +15,7 @@ struct Increment: AsyncParsableCommand {
     @Option(name: .long, help: "True if a Git tag should be created but not a GitHub release")
     private var tagOnly: Bool = false
     
-    @Option(name: .shortAndLong, help: "A suffix added to the end of the version string")
+    @Option(name: .shortAndLong, help: "A suffix to be added to the end of the version string")
     private var suffix: String?
 
     @Flag(name: .shortAndLong)

--- a/Sources/Run/Increment.swift
+++ b/Sources/Run/Increment.swift
@@ -14,6 +14,9 @@ struct Increment: AsyncParsableCommand {
 
     @Option(name: .long, help: "True if a Git tag should be created but not a GitHub release")
     private var tagOnly: Bool = false
+    
+    @Option(name: .shortAndLong, help: "A suffix to be added to the end of the version")
+    private var suffix: String?
 
     @Flag(name: .shortAndLong)
     private var verbose = false
@@ -21,7 +24,7 @@ struct Increment: AsyncParsableCommand {
     mutating func run() async throws {
         let session = GitHubAPISession(repository: repository, apiToken: token)
         if let version = try await Releaser(session: session, verbose: verbose)
-            .makeRelease(sha: sha, tagOnly: tagOnly) {
+            .makeRelease(sha: sha, tagOnly: tagOnly, suffix: suffix) {
             print(version)
         }
     }

--- a/Sources/Run/Increment.swift
+++ b/Sources/Run/Increment.swift
@@ -15,7 +15,7 @@ struct Increment: AsyncParsableCommand {
     @Option(name: .long, help: "True if a Git tag should be created but not a GitHub release")
     private var tagOnly: Bool = false
     
-    @Option(name: .shortAndLong, help: "A suffix to be added to the end of the version")
+    @Option(name: .shortAndLong, help: "A suffix to be added to the end of the version string")
     private var suffix: String?
 
     @Flag(name: .shortAndLong)

--- a/Sources/Run/Releaser.swift
+++ b/Sources/Run/Releaser.swift
@@ -10,19 +10,25 @@ struct Releaser {
         self.verbose = verbose
     }
     
-    func makeRelease(sha: String, tagOnly: Bool = false) async throws -> Version? {
+    func makeRelease(sha: String, tagOnly: Bool = false, suffix: String? = nil) async throws -> Version? {
         let (initialVersion, commits) = try await fetchCommits(sha: sha)
         let newVersion = try incrementVersion(initialVersion, commits: commits)
+        
+        var newVersionDescription = newVersion.description
+        
+        if let suffix {
+            newVersionDescription += "-\(suffix)"
+        }
         
         guard newVersion > initialVersion else {
             log("Nothing to do: no significant changes made")
             return nil
         }
         
-        try await session.createReference(version: newVersion.description, sha: sha)
+        try await session.createReference(version: newVersionDescription, sha: sha)
 
         if !tagOnly {
-            try await session.createRelease(version: newVersion.description)
+            try await session.createRelease(version: newVersionDescription)
         }
         
         log("Released new version: \(newVersion)")

--- a/Sources/Run/Releaser.swift
+++ b/Sources/Run/Releaser.swift
@@ -14,10 +14,10 @@ struct Releaser {
         let (initialVersion, commits) = try await fetchCommits(sha: sha)
         let newVersion = try incrementVersion(initialVersion, commits: commits)
         
-        var newVersionDescription = newVersion.description
-        
-        if let suffix {
-            newVersionDescription += "-\(suffix)"
+        let newVersionDescription = if let suffix {
+            "\(newVersion.description)-\(suffix)"
+        } else {
+            newVersion.description
         }
         
         guard newVersion > initialVersion else {

--- a/Tests/RunTests/ReleaserTests.swift
+++ b/Tests/RunTests/ReleaserTests.swift
@@ -20,6 +20,40 @@ final class ReleaserTests: XCTestCase {
         XCTAssertEqual(version, Version(0, 2, 1))
     }
     
+    func testReleaseWhenNoPreviousRelease_withSuffix() async throws {
+        let session = MockAPISession()
+        
+        let sha = UUID().uuidString
+        let sut = Releaser(session: session)
+        let version = try await sut.makeRelease(sha: sha, suffix: "alpha")
+        
+        XCTAssertEqual(session.didCallCompare?.0, "HEAD^")
+        XCTAssertEqual(session.didCallCompare?.1, sha)
+        
+        XCTAssertEqual(session.didCallCreateReference?.0, "0.2.1-alpha")
+        XCTAssertEqual(session.didCallCreateReference?.1, sha)
+        XCTAssertEqual(session.didCallCreateRelease, "0.2.1-alpha")
+        
+        XCTAssertEqual(version, Version(0, 2, 1))
+    }
+    
+    func testReleaseWhenNoPreviousRelease_withSuffix_numerical() async throws {
+        let session = MockAPISession()
+        
+        let sha = UUID().uuidString
+        let sut = Releaser(session: session)
+        let version = try await sut.makeRelease(sha: sha, suffix: "123")
+        
+        XCTAssertEqual(session.didCallCompare?.0, "HEAD^")
+        XCTAssertEqual(session.didCallCompare?.1, sha)
+        
+        XCTAssertEqual(session.didCallCreateReference?.0, "0.2.1-123")
+        XCTAssertEqual(session.didCallCreateReference?.1, sha)
+        XCTAssertEqual(session.didCallCreateRelease, "0.2.1-123")
+        
+        XCTAssertEqual(version, Version(0, 2, 1))
+    }
+    
     func testReleaseWhenRelease() async throws {
         let session = MockAPISession()
         session.previousReleaseExists = true
@@ -37,6 +71,24 @@ final class ReleaserTests: XCTestCase {
         
         XCTAssertEqual(version, Version(1, 2, 1))
     }
+    
+    func testReleaseWhenRelease_withSuffix() async throws {
+        let session = MockAPISession()
+        session.previousReleaseExists = true
+        
+        let sha = UUID().uuidString
+        let sut = Releaser(session: session)
+        let version = try await sut.makeRelease(sha: sha, suffix: "beta")
+        
+        XCTAssertEqual(session.didCallCompare?.0, "1.0.0")
+        XCTAssertEqual(session.didCallCompare?.1, sha)
+        
+        XCTAssertEqual(session.didCallCreateReference?.0, "1.2.1-beta")
+        XCTAssertEqual(session.didCallCreateReference?.1, sha)
+        XCTAssertEqual(session.didCallCreateRelease, "1.2.1-beta")
+        
+        XCTAssertEqual(version, Version(1, 2, 1))
+    }
 
     func testReleaseWhenTagOnly() async throws {
         let session = MockAPISession()
@@ -50,6 +102,24 @@ final class ReleaserTests: XCTestCase {
         XCTAssertEqual(session.didCallCompare?.1, sha)
 
         XCTAssertEqual(session.didCallCreateReference?.0, "1.2.1")
+        XCTAssertEqual(session.didCallCreateReference?.1, sha)
+        XCTAssertNil(session.didCallCreateRelease)
+
+        XCTAssertEqual(version, Version(1, 2, 1))
+    }
+    
+    func testReleaseWhenTagOnly_withSuffix() async throws {
+        let session = MockAPISession()
+        session.previousReleaseExists = true
+
+        let sha = UUID().uuidString
+        let sut = Releaser(session: session)
+        let version = try await sut.makeRelease(sha: sha, tagOnly: true, suffix: "beta")
+
+        XCTAssertEqual(session.didCallCompare?.0, "1.0.0")
+        XCTAssertEqual(session.didCallCompare?.1, sha)
+
+        XCTAssertEqual(session.didCallCreateReference?.0, "1.2.1-beta")
         XCTAssertEqual(session.didCallCreateReference?.1, sha)
         XCTAssertNil(session.didCallCreateRelease)
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     options:
     - Release
     - Validate
+  SUFFIX:
+    description: 'A suffix to be added to the end of the release version'
+    required: false
+    type: string
   TAG_ONLY:
     description: 'True if a Git tag should be created but not a GitHub release'
     required: false


### PR DESCRIPTION
Adding suffix option to the release action to enable a developer to suffix their version numbers with a string eg "alpha" or "beta"