### PR TITLE
feat: download pre-built binary from release instead of compiling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,31 +30,52 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Build Package
-      working-directory: ${{ github.action_path }}
-      shell: bash
-      run: swift build
-      
-    - name: Validate
-      if: ${{ inputs.ACTION_TYPE == 'Validate' }}
-      working-directory: ${{ github.action_path }}
+    - name: Download or Build Binary
       shell: bash
       run: |
-       swift run --skip-build Run validate \
-         --message "${{ github.event.pull_request.title }}" \
-         --contains-breaking-change ${{ inputs.CONTAINS_BREAKING_CHANGE }}
-      
+        BIN_DIR="${{ github.action_path }}/bin"
+        mkdir -p "$BIN_DIR"
+
+        # Derive the ref from the action's checkout path (last path component)
+        REF=$(basename "${{ github.action_path }}")
+        if echo "$REF" | grep -qE '^[0-9a-f]{7,40}$'; then
+          TAG=$(gh api "repos/$GITHUB_ACTION_REPOSITORY/tags" \
+            --jq ".[] | select(.commit.sha | startswith(\"$REF\")) | .name" 2>/dev/null | head -1)
+          [ -n "$TAG" ] && REF="$TAG"
+        fi
+
+        if gh release download "$REF" \
+            --repo "$GITHUB_ACTION_REPOSITORY" \
+            --pattern "Run" \
+            --output "$BIN_DIR/Run"; then
+          echo "Binary downloaded successfully for $REF"
+          chmod +x "$BIN_DIR/Run"
+        else
+          echo "Binary not available for $REF, falling back to swift build"
+          cd "${{ github.action_path }}" && swift build -c release
+          cp "${{ github.action_path }}/.build/release/Run" "$BIN_DIR/Run"
+        fi
+      env:
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN || github.token }}
+
+    - name: Validate
+      if: ${{ inputs.ACTION_TYPE == 'Validate' }}
+      shell: bash
+      run: |
+        "${{ github.action_path }}/bin/Run" validate \
+          --message "${{ github.event.pull_request.title }}" \
+          --contains-breaking-change ${{ inputs.CONTAINS_BREAKING_CHANGE }}
+
     - name: Release
       id: release
       if: ${{ inputs.ACTION_TYPE == 'Release' }}
-      working-directory: ${{ github.action_path }}
       shell: bash
       run: |
-        version=$(swift run --skip-build Run increment \
+        version=$("${{ github.action_path }}/bin/Run" increment \
           --repository $GITHUB_REPOSITORY \
           --sha $GITHUB_SHA \
           --token ${{inputs.GITHUB_TOKEN}} \
           --tag-only ${{inputs.TAG_ONLY}} \
         )
-        
+
         echo "version=$version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Reduces action execution time from ~1.5 minutes to a few seconds by building the Swift binary once at release time and downloading it at runtime instead of compiling on every run.

## Changes

### `.github/workflows/release-binary.yml` (new)
Triggered on `release: published`, this workflow builds a universal macOS binary (arm64 + x86_64 via `lipo`) and uploads it to the release. A `workflow_dispatch` input is also included for manual testing against an existing release tag.

### `action.yml`
Replaces the `swift build` + `swift run` steps with a single download-or-build step:
1. If `GITHUB_ACTION_REF` looks like a SHA, resolves it to its release tag via the GitHub tags API
2. Attempts to download the pre-built binary from the resolved release
3. Falls back to `swift build -c release` if no binary is available (e.g. `@main`, dev branches, or first run after this PR)

## Testing
The PR workflow uses `uses: ./`, so CI will exercise the new `action.yml` code automatically — it will hit the fallback `swift build` path since this branch has no release binary.