### PR TITLE
ci: build and upload universal macOS binary on release

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -3,11 +3,6 @@ name: Build Release Binary
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag to upload the binary to (e.g. v1.2.3)'
-        required: true
 
 jobs:
   build:
@@ -29,6 +24,6 @@ jobs:
             .build/x86_64-apple-macosx/release/Run
 
       - name: Upload Binary to Release
-        run: gh release upload ${{ github.event.release.tag_name || inputs.tag }} Run
+        run: gh release upload ${{ github.event.release.tag_name }} Run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,0 +1,34 @@
+name: Build Release Binary
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to upload the binary to (e.g. v1.2.3)'
+        required: true
+
+jobs:
+  build:
+    name: Build macOS Binary
+    runs-on: macos-26
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build Universal Binary
+        run: |
+          swift build -c release --arch arm64
+          swift build -c release --arch x86_64
+          lipo -create -output Run \
+            .build/arm64-apple-macosx/release/Run \
+            .build/x86_64-apple-macosx/release/Run
+
+      - name: Upload Binary to Release
+        run: gh release upload ${{ github.event.release.tag_name || inputs.tag }} Run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a workflow that builds a universal macOS binary (arm64 + x86_64) and attaches it to each GitHub release.

This is a prerequisite for [#44](https://github.com/Oliver-Binns/Versioning/pull/44), which will update `action.yml` to download this binary instead of compiling — reducing action runtime from ~1.5 minutes to a few seconds.

## Testing

Once merged, manually trigger the workflow via Actions UI against an existing release tag (e.g. `1.4.5`) to verify the binary builds and uploads correctly before merging #44.