### PR TITLE
ci: add workflow_dispatch to release-binary workflow

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -3,6 +3,11 @@ name: Build Release Binary
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to upload the binary to (e.g. 1.4.6)'
+        required: true
 
 jobs:
   build:
@@ -24,6 +29,6 @@ jobs:
             .build/x86_64-apple-macosx/release/Run
 
       - name: Upload Binary to Release
-        run: gh release upload ${{ github.event.release.tag_name }} Run
+        run: gh release upload ${{ github.event.release.tag_name || inputs.tag }} Run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Allows manually triggering the binary build against an existing release tag.

Needed immediately to backfill the `1.4.6` release, which was created before `release-binary.yml` was in `main` so the workflow never ran. Once merged, trigger it manually with tag `1.4.6` to upload the binary — then #44 can be tested against a real download.