### PR TITLE
ci: trigger binary build from merged workflow after release

### DIFF
--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -15,10 +15,23 @@ jobs:
     runs-on: macos-26
     permissions:
       contents: write
+    outputs:
+      release_version: ${{ steps.release.outputs.release_version }}
       
     steps:
       - name: Create GitHub release
+        id: release
         uses: Oliver-Binns/Versioning@main
         with:
           ACTION_TYPE: 'Release'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-binary:
+    name: Build release binary
+    needs: build
+    if: needs.build.outputs.release_version != ''
+    uses: ./.github/workflows/release-binary.yml
+    with:
+      tag: ${{ needs.build.outputs.release_version }}
+    permissions:
+      contents: write

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -8,6 +8,12 @@ on:
       tag:
         description: 'Release tag to upload the binary to (e.g. 1.4.6)'
         required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
 
 jobs:
   build:


### PR DESCRIPTION
The `release: published` event is suppressed when a release is created using `GITHUB_TOKEN`, so `release-binary.yml` was never triggered automatically after a new version was published.

This fixes it by:
- Adding `workflow_call` to `release-binary.yml` with a `tag` input (retaining `workflow_dispatch` for manual use)
- Exposing `release_version` as a job output from the `build` job in `merged.yml`
- Adding a `build-binary` job that calls `release-binary.yml` after a release is created