### PR TITLE
fix: use curl for SHA-to-tag resolution to avoid auth requirement

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,8 @@ runs:
         # Derive the ref from the action's checkout path (last path component)
         REF=$(basename "${{ github.action_path }}")
         if echo "$REF" | grep -qE '^[0-9a-f]{7,40}$'; then
-          TAG=$(gh api "repos/$GITHUB_ACTION_REPOSITORY/tags" \
-            --jq ".[] | select(.commit.sha | startswith(\"$REF\")) | .name" 2>/dev/null | head -1)
+          TAG=$(curl -fsSL "https://api.github.com/repos/$GITHUB_ACTION_REPOSITORY/tags" \
+            | python3 -c "import sys,json; tags=json.load(sys.stdin); ref='$REF'; print(next((t['name'] for t in tags if t['commit']['sha'].startswith(ref)), ''))")
           [ -n "$TAG" ] && REF="$TAG"
         fi
 


### PR DESCRIPTION
When consumers pin the action to a SHA (e.g. via Dependabot), `gh api` for tag resolution fails silently because `GH_TOKEN` is not available in composite action `env` blocks unless the caller explicitly passes `GITHUB_TOKEN` as an input.

This causes the SHA to never resolve to a release tag, so `gh release download` fails with the raw SHA, and the fallback `swift build` is triggered — breaking jobs with short timeouts.

Fixes by replacing `gh api` with `curl` + `python3` for the tags lookup, which works for public repos without any authentication.