### PR TITLE
fix: hardcode repo name instead of relying on GITHUB_ACTION_REPOSITORY env var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,22 +49,14 @@ runs:
         fi
 
         DOWNLOAD_URL="https://github.com/Oliver-Binns/Versioning/releases/download/$REF/Run"
-        if gh release download "$REF" \
-            --repo "Oliver-Binns/Versioning" \
-            --pattern "Run" \
-            --output "$BIN_DIR/Run" 2>/dev/null; then
-          echo "Binary downloaded successfully for $REF (gh)"
-          chmod +x "$BIN_DIR/Run"
-        elif curl -fsSL -o "$BIN_DIR/Run" "$DOWNLOAD_URL"; then
-          echo "Binary downloaded successfully for $REF (curl)"
+        if curl -fsSL -o "$BIN_DIR/Run" "$DOWNLOAD_URL"; then
+          echo "Binary downloaded successfully for $REF"
           chmod +x "$BIN_DIR/Run"
         else
           echo "Binary not available for $REF, falling back to swift build"
           cd "${{ github.action_path }}" && swift build -c release
           cp "${{ github.action_path }}/.build/release/Run" "$BIN_DIR/Run"
         fi
-      env:
-        GH_TOKEN: ${{ inputs.GITHUB_TOKEN || github.token }}
 
     - name: Validate
       if: ${{ inputs.ACTION_TYPE == 'Validate' }}

--- a/action.yml
+++ b/action.yml
@@ -39,13 +39,13 @@ runs:
         # Derive the ref from the action's checkout path (last path component)
         REF=$(basename "${{ github.action_path }}")
         if echo "$REF" | grep -qE '^[0-9a-f]{7,40}$'; then
-          TAG=$(curl -fsSL "https://api.github.com/repos/$GITHUB_ACTION_REPOSITORY/tags" \
+          TAG=$(curl -fsSL "https://api.github.com/repos/Oliver-Binns/Versioning/tags" \
             | python3 -c "import sys,json; tags=json.load(sys.stdin); ref='$REF'; print(next((t['name'] for t in tags if t['commit']['sha'].startswith(ref)), ''))")
           [ -n "$TAG" ] && REF="$TAG"
         fi
 
         if gh release download "$REF" \
-            --repo "$GITHUB_ACTION_REPOSITORY" \
+            --repo "Oliver-Binns/Versioning" \
             --pattern "Run" \
             --output "$BIN_DIR/Run"; then
           echo "Binary downloaded successfully for $REF"

--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,13 @@ runs:
         # Derive the ref from the action's checkout path (last path component)
         REF=$(basename "${{ github.action_path }}")
         if echo "$REF" | grep -qE '^[0-9a-f]{7,40}$'; then
-          TAG=$(curl -fsSL "https://api.github.com/repos/Oliver-Binns/Versioning/tags" \
-            | python3 -c "import sys,json; tags=json.load(sys.stdin); ref='$REF'; print(next((t['name'] for t in tags if t['commit']['sha'].startswith(ref)), ''))")
-          [ -n "$TAG" ] && REF="$TAG"
+          TAGS_JSON=$(curl -fsSL "https://api.github.com/repos/Oliver-Binns/Versioning/tags" 2>/dev/null || true)
+          if [ -n "$TAGS_JSON" ]; then
+            TAG=$(echo "$TAGS_JSON" | python3 -c "import sys,json; tags=json.load(sys.stdin); ref='$REF'; print(next((t['name'] for t in tags if t['commit']['sha'].startswith(ref)), ''))" 2>/dev/null || true)
+            [ -n "$TAG" ] && REF="$TAG"
+          else
+            echo "Could not resolve SHA $REF to a release tag, will attempt download with SHA"
+          fi
         fi
 
         DOWNLOAD_URL="https://github.com/Oliver-Binns/Versioning/releases/download/$REF/Run"

--- a/action.yml
+++ b/action.yml
@@ -44,11 +44,15 @@ runs:
           [ -n "$TAG" ] && REF="$TAG"
         fi
 
+        DOWNLOAD_URL="https://github.com/Oliver-Binns/Versioning/releases/download/$REF/Run"
         if gh release download "$REF" \
             --repo "Oliver-Binns/Versioning" \
             --pattern "Run" \
-            --output "$BIN_DIR/Run"; then
-          echo "Binary downloaded successfully for $REF"
+            --output "$BIN_DIR/Run" 2>/dev/null; then
+          echo "Binary downloaded successfully for $REF (gh)"
+          chmod +x "$BIN_DIR/Run"
+        elif curl -fsSL -o "$BIN_DIR/Run" "$DOWNLOAD_URL"; then
+          echo "Binary downloaded successfully for $REF (curl)"
           chmod +x "$BIN_DIR/Run"
         else
           echo "Binary not available for $REF, falling back to swift build"


### PR DESCRIPTION
Follow-up to #48. `GITHUB_ACTION_REPOSITORY` is not set inside composite action steps (same class of issue as `GITHUB_ACTION_REF`), causing the tags API URL and `gh release download` to use an empty repo name → 404 errors when the action is pinned to a SHA.

Hardcoding `Oliver-Binns/Versioning` is simpler and more reliable.